### PR TITLE
Remove ENS V2

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -95,10 +95,6 @@ window.onload = function() {
         url: docsUrl + "ens/apiV1.yaml"
       },
       {
-        name: "ENS V2",
-        url: docsUrl + "ens/apiV2.yaml"
-      },
-      {
         name: "Entitlements Readonly API",
         url: docsUrl + "ent/ent.yml"
       },


### PR DESCRIPTION
Jira: CXAPI-2648

## Synopsis

Actually, ENS V2 API has become V1. So there is no need for V2 at the moment.